### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/intex_spa/__init__.py
+++ b/custom_components/intex_spa/__init__.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from aio_intex_spa import IntexSpa, IntexSpaUnreachableException, IntexSpaDnsException


### PR DESCRIPTION
Should resolve the error reported by Home Assistant:

Logger: homeassistant.core
Source: helpers/deprecation.py:222
First occurred: 7:26:00 PM (1 occurrence)
Last logged: 7:26:00 PM

Config was used from intex_spa, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'intex_spa' custom integration