### PR TITLE
Fix `async_setup` incorrect type annotation

### DIFF
--- a/custom_components/intex_spa/__init__.py
+++ b/custom_components/intex_spa/__init__.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from aio_intex_spa import IntexSpa, IntexSpaUnreachableException, IntexSpaDnsException
@@ -25,7 +26,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 async def async_setup(
-    hass: HomeAssistant, config: Config  # pylint: disable=unused-argument
+    hass: HomeAssistant, config: ConfigType  # pylint: disable=unused-argument
 ) -> bool:
     """Set up this integration using YAML is not supported."""
     return True


### PR DESCRIPTION
Considering #121 issue: the previous `Config` type annotation has been moved to `homeassistant.core_config`.
[The corresponding blog post](https://developers.home-assistant.io/blog/2024/10/31/core-config-moved/) points out that _"there's been custom integrations that have incorrect type annotations where the config object passed to the integration's async_setup is specified as a Config instance."_

It appears that we are indeed inheriting from this bad practise.
Hence, we'll fix the #121 not by loading the `Config` class from its new location, but by using the correct `ConfigType` annotation instead.